### PR TITLE
Use net35

### DIFF
--- a/MonkLand/Menu/MultiplayerChat.cs
+++ b/MonkLand/Menu/MultiplayerChat.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Menu;
 using UnityEngine;
 using Steamworks;

--- a/MonkLand/Menu/MultiplayerDisplayMenu.cs
+++ b/MonkLand/Menu/MultiplayerDisplayMenu.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Menu;
 using UnityEngine;
 using Steamworks;

--- a/MonkLand/Menu/MultiplayerPlayerList.cs
+++ b/MonkLand/Menu/MultiplayerPlayerList.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Menu;
 using UnityEngine;
 using Steamworks;

--- a/MonkLand/Menu/SteamMultiplayerMenu.cs
+++ b/MonkLand/Menu/SteamMultiplayerMenu.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Menu;
 using UnityEngine;
 using RWCustom;

--- a/MonkLand/Monkland.csproj
+++ b/MonkLand/Monkland.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net35</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MonkLand/Patches/Menus/patch_EndgameTokens.cs
+++ b/MonkLand/Patches/Menus/patch_EndgameTokens.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using MonoMod;
 using UnityEngine;
 using Monkland.SteamManagement;

--- a/MonkLand/Patches/Menus/patch_MainMenu.cs
+++ b/MonkLand/Patches/Menus/patch_MainMenu.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading.Tasks;
 using Monkland.Patches;
 using Menu;
 using MonoMod;

--- a/MonkLand/Patches/Menus/patch_Slider.cs
+++ b/MonkLand/Patches/Menus/patch_Slider.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading.Tasks;
 using System;
 using Menu;
 using MonoMod;

--- a/MonkLand/Patches/patch_RainWorldGame.cs
+++ b/MonkLand/Patches/patch_RainWorldGame.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using MonoMod;
 using UnityEngine;
 using Monkland.SteamManagement;

--- a/MonkLand/Patches/patch_Rainworld.cs
+++ b/MonkLand/Patches/patch_Rainworld.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Monkland.Patches {

--- a/MonkLand/SteamManagement/MonklandSteamManager.cs
+++ b/MonkLand/SteamManagement/MonklandSteamManager.cs
@@ -4,7 +4,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Steamworks;
 using UnityEngine;
 using Monkland.UI;

--- a/MonkLand/SteamManagement/Network Managers/NetworkGameManager.cs
+++ b/MonkLand/SteamManagement/Network Managers/NetworkGameManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Steamworks;
 using Monkland.Patches;
 using Monkland.UI;

--- a/MonkLand/SteamManagement/NetworkManager.cs
+++ b/MonkLand/SteamManagement/NetworkManager.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Monkland;
 using Monkland.Patches;
 using UnityEngine;

--- a/MonkLand/UI/MonklandUI.cs
+++ b/MonkLand/UI/MonklandUI.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Steamworks;
 using Monkland.Patches;


### PR DESCRIPTION
Rationale:
- RainWorld is using `net35`, makes no sense to use anything else, it won't work.
- `netstandard20` is not being used at all.
- Compatibility with on memory patching (BepInEx).